### PR TITLE
ci: validate images before push, cover Dockerfile.secure, pin snyk action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -12,7 +15,45 @@ permissions:
   attestations: write
 
 jobs:
+  validate:
+    name: Build & validate (${{ matrix.dockerfile }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: [Dockerfile, Dockerfile.secure]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Make scripts executable
+        run: chmod +x ./build.sh ./security-check.sh
+
+      - name: Build image (build-only, no push)
+        env:
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: ./build.sh build-only
+
+      - name: Extract version from build.sh
+        id: get_version
+        run: |
+          VERSION=$(grep '^version=' build.sh | cut -d'"' -f2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
+
+      - name: Validate image --version
+        run: docker run --rm "docker.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}" --version
+
+      - name: Validate image --dry-run
+        run: docker run --rm "docker.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}" --dry-run
+
+      - name: Run security-check.sh
+        run: ./security-check.sh "docker.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}"
+
   docker:
+    name: Push images
+    needs: validate
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -44,6 +85,16 @@ jobs:
           VERSION=$(grep '^version=' build.sh | cut -d'"' -f2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
+
+      - name: Validate image before push
+        run: |
+          docker run --rm "docker.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}" --version
+          docker run --rm "docker.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}" --dry-run
+
+      - name: Run security-check.sh
+        run: |
+          chmod +x ./security-check.sh
+          ./security-check.sh "docker.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}"
 
       - name: Tag Docker image with latest, version, and commit SHA
         run: |

--- a/.github/workflows/snyk-container-analysis.yml
+++ b/.github/workflows/snyk-container-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       # Snyk can be used to break the build when it detects vulnerabilities.
       # In this case we want to upload the issues to GitHub Code Scanning
       continue-on-error: true
-      uses: snyk/actions/docker@v1.0.0
+      uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       env:
         # In order to use the Snyk Action you will need to have a Snyk API token.
         # More details in https://github.com/snyk/actions#getting-your-snyk-token

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,15 @@ Primary instruction source: `.github/copilot-instructions.md` (canonical when it
 
 ## Small gotchas
 
+- xmrig resolves a relative `config.json` against the binary's own path, not the working directory. `docker-entrypoint.sh` injects an explicit `--config=<abs path>` unless the caller already passed `-c`/`--config`; do not remove that shim, especially for `Dockerfile.secure` (binary at `/usr/local/bin`, config at `/home/xmrig`).
 - `.dockerignore` excludes docs, compose files, `build.sh`, and `security-check.sh`; changes there do not affect image build context.
 - The Linux compose overrides only tweak env vars: `compose.linux-msr.yaml` sets `XMRIG_NO_RDMSR=1`, and `compose.linux-hugepages.yaml` sets `XMRIG_RANDOMX_MODE=fast`.
 
 ## CI
 
-- Push to `main` triggers `.github/workflows/docker-build.yml`: builds with `./build.sh build-only`, then tags and pushes versioned + `latest` + commit-SHA tags to Docker Hub and GHCR.
+- `.github/workflows/docker-build.yml` runs on push and PR to `main`:
+  - `validate` job (matrix over `Dockerfile` and `Dockerfile.secure`): builds each with `./build.sh build-only`, then runs `--version`, `--dry-run`, and `security-check.sh` against it. Never pushes.
+  - `docker` job (push events only, gated on `validate` passing): rebuilds `Dockerfile`, re-runs the same validation against the exact image about to ship, then tags and pushes versioned + `latest` + commit-SHA tags to Docker Hub and GHCR, and generates a SLSA provenance attestation.
+  - `Dockerfile.secure` is validated on every push/PR but is not pushed to any registry.
 - Snyk container scanning runs on push/PR to `main` and weekly via `snyk-container-analysis.yml`.
 - Dependabot monitors Docker base images and GitHub Actions versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this Docker packaging project are documented here.
 Each entry tracks the upstream [XMRig](https://github.com/xmrig/xmrig) version used and any packaging changes made in this repository.
 
+## [Unreleased]
+
+### Security & bug fixes
+- **BUG**: Fixed `Dockerfile.secure` silently failing to find `config.json` at runtime — xmrig resolves a relative config path against the binary's own location, and the secure variant copies the binary to `/usr/local/bin` while the config lives in `/home/xmrig`. `docker-entrypoint.sh` now injects an explicit `--config=<abs path>` unless the caller already passed `-c`/`--config`.
+
+### CI/CD
+- Added a `validate` job to `docker-build.yml` (matrix over `Dockerfile` and `Dockerfile.secure`) that builds each variant and runs `--version`, `--dry-run`, and `security-check.sh` against it on every push and pull request to `main`.
+- The push job now re-validates the exact image about to ship before tagging/pushing, and only runs on `push` events (not pull requests); it is gated on the `validate` job passing.
+- `docker-build.yml` now also triggers on pull requests to `main` for early feedback, without pushing images.
+- Pinned `snyk/actions/docker` to a commit SHA (`9adf32b...` / v1.0.0) instead of a mutable tag, matching the pinning convention already used for other actions in this repo.
+
 ## [6.26.0] - 2026-04-07
 
 ### Upstream XMRig changes

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,4 +62,23 @@ if is_enabled "$HUGE_PAGES_JIT_ENABLED"; then
     set -- --huge-pages-jit "$@"
 fi
 
+# xmrig resolves a relative "config.json" against the binary's own path, not
+# the working directory. Dockerfile.secure copies the binary to
+# /usr/local/bin, so without an explicit --config it silently fails to find
+# the config shipped alongside this script. Inject an absolute default path
+# unless the caller already passed -c/--config.
+has_config_arg=0
+for arg in "$@"; do
+    case "$arg" in
+        -c|--config|--config=*)
+            has_config_arg=1
+            break
+            ;;
+    esac
+done
+
+if [ "$has_config_arg" -eq 0 ] && [ -f "${CONFIG_FILE:-$(pwd)/config.json}" ]; then
+    set -- --config="${CONFIG_FILE:-$(pwd)/config.json}" "$@"
+fi
+
 exec xmrig "$@"


### PR DESCRIPTION
See commit message for full details of the CI hardening changes (validate job, Dockerfile.secure coverage, snyk action pinning, and a real Dockerfile.secure config.json resolution bug fix).