### PR TITLE
ci,docs: automate CHANGELOG on release, add SBOM attestation, PR hygiene

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo, unless a later match takes precedence.
+* @cniweb

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,7 +25,7 @@
 - Security checks: `./security-check.sh`
 
 ## Conventions
-- Keep XMRig version synchronized across all six files: `Dockerfile`, `Dockerfile.secure`, `build.sh`, `README.md`, `SECURITY.md`, and `CHANGELOG.md`. The release workflow handles the first five automatically; `CHANGELOG.md` must be updated manually.
+- Keep XMRig version synchronized across all six files: `Dockerfile`, `Dockerfile.secure`, `build.sh`, `README.md`, `SECURITY.md`, and `CHANGELOG.md`. The release workflow handles all six automatically, promoting `CHANGELOG.md`'s `## [Unreleased]` section to a dated version heading; it fails if that section is missing, so add one before triggering a release.
 - Use port `8080` consistently.
 - MSR and 1GB huge pages require host-level Linux capabilities; they are not expected to work in Azure Container Instances or Docker Desktop/WSL2.
 - For releases, prefer workflow `.github/workflows/release-from-version.yml` and keep `SECURITY.md` supported-version row in sync.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Checklist
+
+- [ ] If this is an XMRig version bump: all six files are in sync (`Dockerfile`, `Dockerfile.secure`, `build.sh`, `README.md`, `SECURITY.md`, `CHANGELOG.md`) — prefer using `release-from-version.yml` instead of editing these by hand.
+- [ ] `CHANGELOG.md` has an `## [Unreleased]` entry describing this change (required before the release workflow can run).
+- [ ] Shell scripts (`*.sh`) stay POSIX-compatible (`set -eu`, no bashisms) if touched.
+- [ ] Ran `docker build . --file Dockerfile` and `docker build . --file Dockerfile.secure` locally, or relied on CI's `validate` job.
+- [ ] Updated `AGENTS.md` / `.github/copilot-instructions.md` if this changes repo conventions, CI behavior, or known gotchas.
+
+## Testing
+
+<!-- How did you verify this change? Include commands/output where useful. -->

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -129,3 +129,17 @@ jobs:
         with:
           subject-name: ghcr.io/cniweb/xmrig
           subject-digest: ${{ steps.push.outputs.digest }}
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/cniweb/xmrig@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/cniweb/xmrig
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom.spdx.json

--- a/.github/workflows/release-from-version.yml
+++ b/.github/workflows/release-from-version.yml
@@ -104,6 +104,31 @@ jobs:
                   text = re.sub(pattern, repl, text)
               if text != original:
                   path.write_text(text, encoding="utf-8")
+
+          # CHANGELOG.md is intentionally not silently skipped: require an
+          # "## [Unreleased]" section (added by whoever prepared this
+          # release) and promote it to a dated version heading. This turns
+          # the previously-manual "don't forget CHANGELOG.md" step into a
+          # hard pre-condition instead of an easy-to-miss reminder.
+          import datetime
+
+          changelog = pathlib.Path("CHANGELOG.md")
+          changelog_text = changelog.read_text(encoding="utf-8")
+
+          if "## [Unreleased]" not in changelog_text:
+              raise SystemExit(
+                  "CHANGELOG.md has no '## [Unreleased]' section. "
+                  "Add release notes under an '## [Unreleased]' heading "
+                  "before triggering this workflow."
+              )
+
+          today = datetime.date.today().isoformat()
+          changelog_text = changelog_text.replace(
+              "## [Unreleased]",
+              f"## [{version}] - {today}",
+              1,
+          )
+          changelog.write_text(changelog_text, encoding="utf-8")
           PY
         env:
           VERSION: ${{ steps.ver.outputs.version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Primary instruction source: `.github/copilot-instructions.md` (canonical when it
 ## Release/versioning
 
 - XMRig version bumps must stay synchronized across all six files: `Dockerfile`, `Dockerfile.secure`, `build.sh`, `README.md`, `SECURITY.md`, and `CHANGELOG.md`.
-- The release workflow (`.github/workflows/release-from-version.yml`) handles the first five automatically but **does not** update `CHANGELOG.md` — that must be done manually or by the agent before triggering it.
+- The release workflow (`.github/workflows/release-from-version.yml`) handles all six automatically: it updates version refs in the first five, and promotes `CHANGELOG.md`'s `## [Unreleased]` heading to `## [<version>] - <date>`. **The workflow fails fast if `CHANGELOG.md` has no `## [Unreleased]` section** — add one with the release notes before triggering it.
 - Prefer that workflow for releases: it updates version refs, commits, tags `vX.Y.Z`, and creates the GitHub release.
 - When checking for a new upstream version, compare `Dockerfile`'s `ARG VERSION_TAG` against `gh release list --repo xmrig/xmrig --limit 5`, then fetch notes with `gh release view v${VERSION} --repo xmrig/xmrig --json body -q .body`.
 


### PR DESCRIPTION
## Zusammenfassung

Setzt die drei Mittel-Priorität-Verbesserungen aus der ursprünglichen Analyse um (Fortsetzung von #42):

### #5 – CHANGELOG-Automatisierung im Release-Workflow
Bisher musste `CHANGELOG.md` manuell (bzw. vom Agenten) aktualisiert werden, bevor `release-from-version.yml` getriggert wurde – ein leicht zu vergessender, undokumentiert erzwungener Schritt. Jetzt:
- Der Workflow sucht eine `## [Unreleased]`-Sektion in `CHANGELOG.md` und benennt sie automatisch in `## [<version>] - <datum>` um.
- **Fehlt die Sektion, bricht der Workflow mit klarer Fehlermeldung ab**, statt sie stillschweigend zu überspringen.

### #6 – SBOM-Generierung
Ergänzt `anchore/sbom-action` (SPDX-Format) + `actions/attest-sbom`, analog zur bereits vorhandenen SLSA-Provenance-Attestation. Beide Attestationen laufen nur im `docker`-Push-Job (nach dem tatsächlichen Push), nicht im `validate`-Job.

### #7 – PR-Template & CODEOWNERS
- `.github/pull_request_template.md` mit Checkliste (6-Datei-Versionssync, CHANGELOG-Unreleased-Eintrag, POSIX-Shell-Stil, lokale Build-Verifikation).
- `.github/CODEOWNERS` mit `@cniweb` als Default-Owner.

## Verifikation

- YAML-Syntax beider geänderter Workflows geprüft (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Das komplette Python-Versionssync-Skript aus `release-from-version.yml` (inkl. der neuen CHANGELOG-Logik) lokal gegen Kopien aller 6 Dateien ausgeführt:
  - Erfolgsfall: `## [Unreleased]` → `## [6.27.0] - 2026-07-30` korrekt umbenannt, alle anderen Dateien korrekt versioniert.
  - Fehlerfall: Ohne `## [Unreleased]`-Sektion bricht das Skript mit der erwarteten Fehlermeldung ab (`exit=1`).
- Alle neuen Action-SHAs (`anchore/sbom-action@e22c389...` = v0.24.0, `actions/attest-sbom@c604332...` = v4.1.0) via `git ls-remote --tags` verifiziert, nicht geraten.

## Dokumentation aktualisiert

- `AGENTS.md` und `.github/copilot-instructions.md`: CHANGELOG-Automatisierung + Fail-Fast-Verhalten beschrieben.

Nächster Schritt: Die hier etablierten Muster (CI-Validierung, Matrix-Build, SBOM, PR-Hygiene) auf die anderen 3 Docker-Mining-Projekte übertragen.