### PR TITLE
fix: capture the correct GHCR digest for attestation and SBOM

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -120,8 +120,16 @@ jobs:
           docker push ghcr.io/cniweb/xmrig:${{ steps.get_version.outputs.version }}
           docker push ghcr.io/cniweb/xmrig:${{ github.sha }}
 
-          # Capture digest for attestation
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/cniweb/xmrig:${{ steps.get_version.outputs.version }} | cut -d'@' -f2)
+          # Capture the GHCR-specific digest for attestation/SBOM. The local
+          # image ID is shared across all tags/registries, so
+          # `.RepoDigests` can list Docker Hub's digest before GHCR's;
+          # filter explicitly for the ghcr.io repo digest instead of
+          # trusting index 0.
+          DIGEST=$(docker inspect --format='{{range .RepoDigests}}{{println .}}{{end}}' ghcr.io/cniweb/xmrig:${{ steps.get_version.outputs.version }} | grep '^ghcr.io/cniweb/xmrig@' | head -n1 | cut -d'@' -f2)
+          if [ -z "$DIGEST" ]; then
+            echo "Could not determine ghcr.io digest for cniweb/xmrig" >&2
+            exit 1
+          fi
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Generate SLSA provenance attestation


### PR DESCRIPTION
## Zusammenfassung

Fix-Follow-up zu #43: Der `Generate SBOM`-Schritt schlug nach dem Merge auf `main` fehl (`MANIFEST_UNKNOWN`), weil der Digest-Capture-Schritt `{{index .RepoDigests 0}}` verwendete – das lokale Docker-Image-Objekt teilt sich `.RepoDigests` über **alle** Registries, zu denen es gepusht wurde (hier Docker Hub *und* GHCR). Index 0 kann je nach Push-Reihenfolge/interner Sortierung mal der eine, mal der andere sein.

**Nebenbefund:** Das bedeutet, dass auch die bereits länger bestehende SLSA-Provenance-Attestation (`subject-name: ghcr.io/cniweb/xmrig`) möglicherweise den falschen (Docker-Hub-)Digest signiert hat, ohne dass es je aufgefallen wäre – `attest-build-provenance` validiert den Digest nicht gegen die Registry, das Vorgehen schlägt also nicht fehl, ist aber semantisch falsch.

## Fix

`RepoDigests` wird jetzt explizit nach dem `ghcr.io/cniweb/xmrig@`-Eintrag gefiltert statt Listenreihenfolge zu vertrauen. Schlägt kein Eintrag an, bricht der Schritt mit klarer Fehlermeldung ab, statt einen falschen Digest weiterzureichen.

## Verifikation

- Fehlerhaften Lauf identifiziert: https://github.com/cniweb/xmrig-monero/actions/runs/30526245408 (`Generate SBOM` → `MANIFEST_UNKNOWN`)
- Filter-Logik isoliert mit synthetischen Multi-Registry-Digest-Listen in beiden Reihenfolgen getestet – liefert zuverlässig den GHCR-Digest.
- YAML-Syntax geprüft.

Nach Merge sollte der nächste Push-Workflow auf `main` durchlaufen; ich prüfe das direkt danach.